### PR TITLE
Add support for TLS encryption and SASL authentication

### DIFF
--- a/goflow.go
+++ b/goflow.go
@@ -51,6 +51,7 @@ var (
 	TemplatePath = flag.String("templates.path", "/templates", "NetFlow/IPFIX templates list")
 
 	KafkaTLS   = flag.Bool("kafka.tls", false, "Use TLS to connect to Kafka")
+	KafkaSASL  = flag.Bool("kafka.sasl", false, "Use SASL/PLAIN data to connect to Kafka (TLS is recommended and the environment variables KAFKA_SASL_USER and KAFKA_SASL_PASS need to be set)")
 	KafkaTopic = flag.String("kafka.out.topic", "flow-messages", "Kafka topic to produce to")
 	KafkaSrv   = flag.String("kafka.out.srv", "", "SRV record containing a list of Kafka brokers (or use kafka.out.brokers)")
 	KafkaBrk   = flag.String("kafka.out.brokers", "127.0.0.1:9092,[::1]:9092", "Kafka brokers list separated by commas")
@@ -751,7 +752,7 @@ func main() {
 		} else {
 			addrs = strings.Split(*KafkaBrk, ",")
 		}
-		kafkaState := transport.StartKafkaProducer(addrs, *KafkaTopic, *KafkaTLS)
+		kafkaState := transport.StartKafkaProducer(addrs, *KafkaTopic, *KafkaTLS, *KafkaSASL)
 		s.kafkaState = kafkaState
 		s.kafkaEn = true
 	}

--- a/goflow.go
+++ b/goflow.go
@@ -50,6 +50,7 @@ var (
 	MetricsPath  = flag.String("metrics.path", "/metrics", "Metrics path")
 	TemplatePath = flag.String("templates.path", "/templates", "NetFlow/IPFIX templates list")
 
+	KafkaTLS   = flag.Bool("kafka.tls", false, "Use TLS to connect to Kafka")
 	KafkaTopic = flag.String("kafka.out.topic", "flow-messages", "Kafka topic to produce to")
 	KafkaSrv   = flag.String("kafka.out.srv", "", "SRV record containing a list of Kafka brokers (or use kafka.out.brokers)")
 	KafkaBrk   = flag.String("kafka.out.brokers", "127.0.0.1:9092,[::1]:9092", "Kafka brokers list separated by commas")
@@ -750,7 +751,7 @@ func main() {
 		} else {
 			addrs = strings.Split(*KafkaBrk, ",")
 		}
-		kafkaState := transport.StartKafkaProducer(addrs, *KafkaTopic)
+		kafkaState := transport.StartKafkaProducer(addrs, *KafkaTopic, *KafkaTLS)
 		s.kafkaState = kafkaState
 		s.kafkaEn = true
 	}

--- a/transport/kafka.go
+++ b/transport/kafka.go
@@ -7,6 +7,7 @@ import (
 	flowmessage "github.com/cloudflare/goflow/pb"
 	proto "github.com/golang/protobuf/proto"
 	sarama "gopkg.in/Shopify/sarama.v1"
+	"os"
 )
 
 type KafkaState struct {
@@ -14,7 +15,7 @@ type KafkaState struct {
 	topic    string
 }
 
-func StartKafkaProducer(addrs []string, topic string, use_tls bool) *KafkaState {
+func StartKafkaProducer(addrs []string, topic string, use_tls bool, use_sasl bool) *KafkaState {
 	kafkaConfig := sarama.NewConfig()
 	kafkaConfig.Producer.Return.Successes = false
 	kafkaConfig.Producer.Return.Errors = false
@@ -25,6 +26,19 @@ func StartKafkaProducer(addrs []string, topic string, use_tls bool) *KafkaState 
 		}
 		kafkaConfig.Net.TLS.Enable = true
 		kafkaConfig.Net.TLS.Config = &tls.Config{RootCAs: rootCAs}
+	}
+	if use_sasl {
+		if !use_tls {
+			log.Warnln("Using SASL without TLS will transmit the authentication in plaintext!")
+		}
+		kafkaConfig.Net.SASL.Enable = true
+		kafkaConfig.Net.SASL.User = os.Getenv("KAFKA_SASL_USER")
+		kafkaConfig.Net.SASL.Password = os.Getenv("KAFKA_SASL_PASS")
+		if kafkaConfig.Net.SASL.User == "" && kafkaConfig.Net.SASL.Password == "" {
+			log.Fatalf("Kafka SASL config from environment was unsuccessful. KAFKA_SASL_USER and KAFKA_SASL_PASS need to be set.")
+		} else {
+			log.Infof("Authenticating as user '%s'...", kafkaConfig.Net.SASL.User)
+		}
 	}
 
 	kafkaProducer, err := sarama.NewAsyncProducer(addrs, kafkaConfig)


### PR DESCRIPTION
This PR adds support for using SASL/PLAIN via TLS. Sarama already supports this, all this PR does is adding appropriate command line options and initialization code and plumbing. Both features are turned off by default, so nothing changes for existing setups. Both options terminate goflow with fatal log entries if some error occures, this will however happen right at intialization.

There are two design questions I'd like to point out:
 1. The TLS commit assumes the system certificates are good and thus offers no way of allowing insecure (untrusted) connections or a way to provide a custom CA.
 2. The SASL commit expects the authentication in environment variables, which works well, but is not very flexible.

I am open to suggestions on how to handle both things better.