### PR TITLE
Fix for #40: change the position of the channel

### DIFF
--- a/decoders/decoder.go
+++ b/decoders/decoder.go
@@ -39,11 +39,11 @@ func (w Worker) Start() {
 	go func() {
 		//log.Debugf("Worker %v started", w.Id)
 		for {
-			w.WorkerPool <- w.InMsg
 			select {
 			case <-w.Quit:
 				break
-			case msg := <-w.InMsg:
+			case w.WorkerPool <- w.InMsg:
+				msg := <-w.InMsg
 				timeTrackStart := time.Now()
 				err := w.DecoderParams.DecoderFunc(msg)
 				timeTrackStop := time.Now()


### PR DESCRIPTION
This removes a deadlock risk when exiting the worker pool loop.