### PR TITLE
Do not swap nextHeader and nextHeaderEncap twice in sFlow parser

### DIFF
--- a/producer/producer_sf.go
+++ b/producer/producer_sf.go
@@ -226,10 +226,6 @@ func ParseSampledHeaderConfig(flowMessage *flowmessage.FlowMessage, sampledHeade
 			nextHeaderEncap = nextHeader
 			nextHeader = tmpNextHeader
 
-			nextHeaderTmp := nextHeaderEncap
-			nextHeaderEncap = nextHeader
-			nextHeader = nextHeaderTmp
-
 			tosTmp := tosEncap
 			tosEncap = tos
 			tos = tosTmp


### PR DESCRIPTION
nextHeader and nextHeaderEncap have been already swapped 4 lines above.