### PR TITLE
Length-delimited protobuf #65

### DIFF
--- a/cmd/cnetflow/cnetflow.go
+++ b/cmd/cnetflow/cnetflow.go
@@ -27,6 +27,7 @@ var (
 	LogFmt   = flag.String("logfmt", "normal", "Log formatter")
 
 	EnableKafka  = flag.Bool("kafka", true, "Enable Kafka")
+	FixedLength  = flag.Bool("proto.fixedlen", false, "Enable fixed length protobuf")
 	MetricsAddr  = flag.String("metrics.addr", ":8080", "Metrics address")
 	MetricsPath  = flag.String("metrics.path", "/metrics", "Metrics path")
 	TemplatePath = flag.String("templates.path", "/templates", "NetFlow/IPFIX templates list")
@@ -80,6 +81,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
+		kafkaState.FixedLengthProto = *FixedLength
 		s.Transport = kafkaState
 	}
 	log.WithFields(log.Fields{

--- a/cmd/cnflegacy/cnflegacy.go
+++ b/cmd/cnflegacy/cnflegacy.go
@@ -27,6 +27,7 @@ var (
 	LogFmt   = flag.String("logfmt", "normal", "Log formatter")
 
 	EnableKafka = flag.Bool("kafka", true, "Enable Kafka")
+	FixedLength = flag.Bool("proto.fixedlen", false, "Enable fixed length protobuf")
 	MetricsAddr = flag.String("metrics.addr", ":8080", "Metrics address")
 	MetricsPath = flag.String("metrics.path", "/metrics", "Metrics path")
 
@@ -78,6 +79,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
+		kafkaState.FixedLengthProto = *FixedLength
 		s.Transport = kafkaState
 	}
 	log.WithFields(log.Fields{

--- a/cmd/csflow/csflow.go
+++ b/cmd/csflow/csflow.go
@@ -27,6 +27,7 @@ var (
 	LogFmt   = flag.String("logfmt", "normal", "Log formatter")
 
 	EnableKafka = flag.Bool("kafka", true, "Enable Kafka")
+	FixedLength = flag.Bool("proto.fixedlen", false, "Enable fixed length protobuf")
 	MetricsAddr = flag.String("metrics.addr", ":8080", "Metrics address")
 	MetricsPath = flag.String("metrics.path", "/metrics", "Metrics path")
 
@@ -78,6 +79,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
+		kafkaState.FixedLengthProto = *FixedLength
 		s.Transport = kafkaState
 	}
 	log.WithFields(log.Fields{

--- a/cmd/goflow/goflow.go
+++ b/cmd/goflow/goflow.go
@@ -39,6 +39,7 @@ var (
 	LogFmt   = flag.String("logfmt", "normal", "Log formatter")
 
 	EnableKafka = flag.Bool("kafka", true, "Enable Kafka")
+	FixedLength = flag.Bool("proto.fixedlen", false, "Enable fixed length protobuf")
 	MetricsAddr = flag.String("metrics.addr", ":8080", "Metrics address")
 	MetricsPath = flag.String("metrics.path", "/metrics", "Metrics path")
 
@@ -101,6 +102,8 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
+		kafkaState.FixedLengthProto = *FixedLength
+
 		sSFlow.Transport = kafkaState
 		sNFL.Transport = kafkaState
 		sNF.Transport = kafkaState


### PR DESCRIPTION
Added `-proto.fixedlen=true` to have protobuf encoded with length before the message ([Buffer.EncodeMessage](https://godoc.org/github.com/golang/protobuf/proto#Buffer.EncodeMessage)). This is required by Clickhouse.

A table example is the following:
```
CREATE TABLE flows
(
    TimeReceived UInt64,
    SamplingRate UInt64,
    ...
) ENGINE = Kafka()
SETTINGS
    kafka_broker_list = 'kafka:9092',
    kafka_topic_list = 'flows',
    kafka_group_name = 'clickhouse',
    kafka_format = 'Protobuf',
    kafka_schema = './flow.proto:FlowMessage';
```