### PR TITLE
Fix Kafka brokers CLI parameter names in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Download the latest release and just run the following command:
 Enable or disable a protocol using `-nf=false` or `-sflow=false`.
 Define the port and addresses of the protocols using `-nf.addr`, `-nf.port` for NetFlow and `-sflow.addr`, `-slow.port` for sFlow.
 
-Set the brokers or the Kafka brokers SRV record using: `-kafka.out.brokers 127.0.0.1:9092,[::1]:9092` or `-kafka.out.srv`.
+Set the brokers or the Kafka brokers SRV record using: `-kafka.brokers 127.0.0.1:9092,[::1]:9092` or `-kafka.srv`.
 Disable Kafka sending `-kafka=false`.
 You can hash the protobuf by key when you send it to Kafka.
 


### PR DESCRIPTION
-kafka.out.* was renamed to -kafka.* in 3.0.1.