### PR TITLE
Remove remote_port label from flow_traffic metrics

### DIFF
--- a/utils/metrics.go
+++ b/utils/metrics.go
@@ -13,14 +13,14 @@ var (
 			Name: "flow_traffic_bytes",
 			Help: "Bytes received by the application.",
 		},
-		[]string{"remote_ip", "remote_port", "local_ip", "local_port", "type"},
+		[]string{"remote_ip", "local_ip", "local_port", "type"},
 	)
 	MetricTrafficPackets = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "flow_traffic_packets",
 			Help: "Packets received by the application.",
 		},
-		[]string{"remote_ip", "remote_port", "local_ip", "local_port", "type"},
+		[]string{"remote_ip", "local_ip", "local_port", "type"},
 	)
 	MetricPacketSizeSum = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
@@ -28,7 +28,7 @@ var (
 			Help:       "Summary of packet size.",
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		},
-		[]string{"remote_ip", "remote_port", "local_ip", "local_port", "type"},
+		[]string{"remote_ip", "local_ip", "local_port", "type"},
 	)
 	DecoderStats = prometheus.NewCounterVec(
 		prometheus.CounterOpts{

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -316,7 +316,6 @@ func UDPRoutine(name string, decodeFunc decoder.DecoderFunc, workers int, addr s
 		MetricTrafficBytes.With(
 			prometheus.Labels{
 				"remote_ip":   pktAddr.IP.String(),
-				"remote_port": strconv.Itoa(pktAddr.Port),
 				"local_ip":    localIP,
 				"local_port":  strconv.Itoa(addrUDP.Port),
 				"type":        name,
@@ -325,7 +324,6 @@ func UDPRoutine(name string, decodeFunc decoder.DecoderFunc, workers int, addr s
 		MetricTrafficPackets.With(
 			prometheus.Labels{
 				"remote_ip":   pktAddr.IP.String(),
-				"remote_port": strconv.Itoa(pktAddr.Port),
 				"local_ip":    localIP,
 				"local_port":  strconv.Itoa(addrUDP.Port),
 				"type":        name,
@@ -334,7 +332,6 @@ func UDPRoutine(name string, decodeFunc decoder.DecoderFunc, workers int, addr s
 		MetricPacketSizeSum.With(
 			prometheus.Labels{
 				"remote_ip":   pktAddr.IP.String(),
-				"remote_port": strconv.Itoa(pktAddr.Port),
 				"local_ip":    localIP,
 				"local_port":  strconv.Itoa(addrUDP.Port),
 				"type":        name,


### PR DESCRIPTION
Fixes #94.

However it theoretically has the potential to break some existing usecases, where the
distiction between remote ports is relevant.

Signed-off-by: Tobias Guggenmos <tobias.guggenmos@uni-ulm.de>