### PR TITLE
Don't close connection if Listen* fails

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -277,10 +277,10 @@ func UDPRoutine(name string, decodeFunc decoder.DecoderFunc, workers int, addr s
 
 	if sockReuse {
 		pconn, err := reuseport.ListenPacket("udp", addrUDP.String())
-		defer pconn.Close()
 		if err != nil {
 			return err
 		}
+		defer pconn.Close()
 		var ok bool
 		udpconn, ok = pconn.(*net.UDPConn)
 		if !ok {
@@ -288,10 +288,10 @@ func UDPRoutine(name string, decodeFunc decoder.DecoderFunc, workers int, addr s
 		}
 	} else {
 		udpconn, err = net.ListenUDP("udp", &addrUDP)
-		defer udpconn.Close()
 		if err != nil {
 			return err
 		}
+		defer udpconn.Close()
 	}
 
 	payload := make([]byte, 9000)


### PR DESCRIPTION
When ListenUDP/ListenPacket fail, the connection is nil and therefore,
we cannot call `Close()` on it.

Before:

```
 16:47 CEST ❱ ./goflow-v3.4.2-8-g0c2503d67cc8-linux-x86_64 -kafka=false -nf.port 9995 -nfl=false -sflow=false
INFO[0000] Starting GoFlow
INFO[0000] Listening on UDP :9995                        Type=NetFlow
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x7f644a]

goroutine 23 [running]:
github.com/cloudflare/goflow/v3/utils.UDPRoutine(0x90460d, 0x7, 0xc00021c3c0, 0x1, 0x0, 0x0, 0x270b, 0x0, 0x99b358, 0xc00021a930, ...)
        /home/bernat/code/free/goflow/utils/utils.go:291 +0x140a
github.com/cloudflare/goflow/v3/utils.(*StateNetFlow).FlowRoutine(0xc000224900, 0x1, 0x0, 0x0, 0x270b, 0x0, 0x2, 0x0)
        /home/bernat/code/free/goflow/utils/netflow.go:358 +0x15c
main.main.func2(0xc000224900, 0xc00021e260)
        /home/bernat/code/free/goflow/cmd/goflow/goflow.go:134 +0x226
created by main.main
        /home/bernat/code/free/goflow/cmd/goflow/goflow.go:129 +0x3da
```

After:

```
 16:48 CEST ❱ ./goflow-v3.4.2-8-g0c2503d67cc8-linux-x86_64 -kafka=false -nf.port 9995 -nfl=false -sflow=false
INFO[0000] Starting GoFlow
INFO[0000] Listening on UDP :9995                        Type=NetFlow
FATA[0000] Fatal error: could not listen to UDP (listen udp :9995: bind: address already in use)
```